### PR TITLE
Vignette edit and readSegMask.R fix

### DIFF
--- a/R/readSegMask.R
+++ b/R/readSegMask.R
@@ -115,8 +115,8 @@ readSegMask <- function(
     geom_df <- as.data.frame(terra::geom(terra::as.polygons(mask)))
 
     # change the value of geom to its original label value
-    geom_df %<>% mutate(
-      dplyr::geom = mapping[geom_df$geom]
+    geom_df %<>% dplyr::mutate(
+      cell_id = mapping[geom_df$geom]
     )
     
     if (!is.null(background_value)) {
@@ -129,7 +129,7 @@ readSegMask <- function(
         }
         geom_df %<>%
             dplyr::filter(
-                !.data[["geom"]] == background_value
+                !.data[["cell_id"]] == background_value
             )
     }
     geom_df %<>%
@@ -147,13 +147,14 @@ readSegMask <- function(
     dplyr::group_by(.data[["geom"]]) %>%
     dplyr::filter(num == max(num))
 
-     geom_df %<>% dplyr::ungroup() %>%
-        dplyr::mutate(
-            # create ID col
-            cell_id = dplyr::consecutive_id(
-                .data[["sample_id"]], .data[["geom"]]
-            )
-        )
+     geom_df %<>% dplyr::ungroup() # %>%
+     #   dplyr::mutate(
+     #        # create ID col
+     #        cell_id = dplyr::consecutive_id(
+     #            .data[["sample_id"]], .data[["geom"]]
+     #        )
+     #
+     #   )
 
     dataframeToMEList(
         geom_df,

--- a/R/readSegMask.R
+++ b/R/readSegMask.R
@@ -108,8 +108,17 @@ readSegMask <- function(
 
     terra::ext(mask) <- e
 
+    # get the original labels of each segment in the image
+    labels = as.list(terra::as.polygons(mask)[[1]])[[1]]
+    mapping = setNames(labels, seq_len(length(labels)))
+    
     geom_df <- as.data.frame(terra::geom(terra::as.polygons(mask)))
 
+    # change the value of geom to its original label value
+    geom_df %<>% mutate(
+      dplyr::geom = mapping[geom_df$geom]
+    )
+    
     if (!is.null(background_value)) {
         if (is.nan(background_value)) {
             cli::cli_abort(c(

--- a/vignettes/MoleculeExperiment.Rmd
+++ b/vignettes/MoleculeExperiment.Rmd
@@ -418,7 +418,7 @@ Read in virtual dissection CSV file, exported from napari (screenshot), of the m
 
 ```{r}
 bds_colours <- setNames(
-  c("#aa0000ff", "#ffaaffff"),
+  c("#00ff00ff", "#ffff00ff"),
   c("Region 1", "Region 2")
 )
 

--- a/vignettes/MoleculeExperiment.Rmd
+++ b/vignettes/MoleculeExperiment.Rmd
@@ -77,6 +77,7 @@ BiocManager::install("MoleculeExperiment")
 ```{r}
 library(MoleculeExperiment)
 library(ggplot2)
+library(EBImage)
 ```
 
 2. Create MoleculeExperiment object with example Xenium data, taken over a 
@@ -230,7 +231,7 @@ toyME
 
 Displayed below is the BIDcell segmentation image added to `toyME` as another boundaries
 
-```{r echo=FALSE, warning=FALSE}
+```{r warning=FALSE}
 BIDcell_segmask_img <- EBImage::readImage(segMask)
 EBImage::display(BIDcell_segmask_img, method = "raster")
 ```

--- a/vignettes/MoleculeExperiment.Rmd
+++ b/vignettes/MoleculeExperiment.Rmd
@@ -228,12 +228,29 @@ boundaries(toyME, "BIDcell_segmentation") <- readSegMask(
 toyME
 ```
 
+Displayed below is the BIDcell segmentation image added to `toyME` as another boundaries
+
+```{r echo=FALSE, warning=FALSE}
+BIDcell_segmask_img <- EBImage::readImage(segMask)
+EBImage::display(BIDcell_segmask_img, method = "raster")
+```
+
+Finally, a digital in-situ, with cell boundaries and BIDcell segmentation boundaries (red polygons in sample1) can be plotted.
+
+```{r}
+ggplot_me() + 
+  geom_polygon_me(toyME, assayName = "cell", byFill = "segment_id", colour = "black", alpha = 0.3) + 
+  geom_polygon_me(toyME, assayName = "BIDcell_segmentation", fill = NA, colour = "red" ) + 
+  geom_point_me(toyME, assayName = "detected", byColour = "feature_id", size = 1) +
+  theme_classic()
+```
+
 ### Use case 2: from machine's output directory to ME object
 
-The MoleculeExperiment package also provides functions to directly work with
-the directories containing output files of commonly used technologies. This is
-especially useful to work with data from multiple samples.
-Here we provide convenience functions to read in data from Xenium (10X
+The MoleculeExperiment package also provides functions to directly work with 
+the directories containing output files of commonly used technologies. 
+This is especially useful to work with data from multiple samples. 
+Here we provide convenience functions to read in data from Xenium (10X 
 Genomics), CosMx (Nanostring) and Merscope (Vizgen).
 
 ```{r}

--- a/vignettes/MoleculeExperiment.Rmd
+++ b/vignettes/MoleculeExperiment.Rmd
@@ -123,10 +123,10 @@ spe
 Here we demonstrate how to work with an ME object from toy data, representing a 
 scenario where both the detected transcripts information and the boundary 
 information have already been read into R. This requires the standardisation
-of the data with the dataframeToMEList() function.
+of the data with the `dataframeToMEList()` function.
 
-The flexibility of the arguments in dataframeToMEList() enable the creation of
-a standard ME object across dataframes comming from different vendors of
+The flexibility of the arguments in `dataframeToMEList()` enable the creation of
+a standard ME object across dataframes coming from different vendors of
 molecule-based spatial transcriptomics technologies. 
 
 1) Generate a toy transcripts data.frame.
@@ -212,7 +212,7 @@ toyME
 6) Add boundaries from an external segmentation algorithm.
 
 In this example, we use the extent of the molecules of generated for `toyME` to 
-allign the boundaries with the molecules. In general, the extent of the 
+align the boundaries with the molecules. In general, the extent of the 
 segmentation is required for this alignment.
 
 ```{r}

--- a/vignettes/MoleculeExperiment.Rmd
+++ b/vignettes/MoleculeExperiment.Rmd
@@ -247,11 +247,12 @@ me
 readXenium() standardises the transcript and boundary information such that the
 column names are consistent across technologies when handling ME objects.
 
-In addition, readXenium() enables the user to decide if they want to keep all
-data that is vendor-specific (e.g., column with qv score), some columns of
-interest, or only the essential columns. The latter refers to feature names and
-locations of the detected transcripts, and segment ids and boundary locations of
-the segmentation results.
+In addition, the `keepCols` argument of `readXenium()` enables the user to 
+decide if they want to keep all data that is vendor-specific (e.g., column with 
+qv score), some columns of interest, or only the essential columns. By default, 
+it is set to `essential`, which refers to feature names, x and y locations in 
+the transcripts file, and segment ids, x and y locations for the vertices 
+defining the boundaries in the boundaries file.
 
 For CosMx and Merscope data we provide convenience functions that standardise
 the raw transcripts data into a MoleculeExperiment object and additionally read 


### PR DESCRIPTION
## Vignette

1. fixed typos
2. Section 3.1.1 List 6: added BIDcell_segmask.tif image and in-situ plot for `toyME` in 
3. Section 3.1.2: added more detailed description about the `keepCols` argument of the `readXenium()`
4. Section 6: changed the colours of virtual dissections (region 1 and region 2) to make them more visible. (segment_id and feature_id both used the same colours originally)

## readSegMask.R

Used the original label value in the input image as the `cell_id` column in the `geom_df` instead of changing it to consecutive id.

Without the changes, this code snippet from the vignettes cannot successfully remove the background segment from the image since the segment_id was changed to a consecutive id from 1, 2, 3, ..., 89. So there was no segment_id with value 0.

```{r}
repoDir <- system.file("extdata", package = "MoleculeExperiment")
segMask <- paste0(repoDir, "/BIDcell_segmask.tif")
boundaries(toyME, "BIDcell_segmentation") <- readSegMask(
  # use the molecule extent to define the boundary extent
  extent(toyME, assayName = "detected"),
  path = segMask, assayName = "BIDcell_segmentation",
  sample_id = "sample1", background_value = 0
)

toyME
```
### Potentail risks

-  Only tested the modified function using single TIFF image `BIDcell_segmask.tif` provided in the package.
-  Only tested the modified function by providing the path of the boundaries image not by image object. 

### Demo plots

Here is a screenshot showing the BIDcell_segmentation boundaries and the input boundaries image before the changes.
<img width="707" alt="Screenshot 2023-12-02 at 12 45 24 pm" src="https://github.com/SydneyBioX/MoleculeExperiment/assets/86540404/bfb04d66-3721-429c-9121-8a3d974f2e78">
And here is the same plot after the changes.
![toyME-in-situ](https://github.com/SydneyBioX/MoleculeExperiment/assets/86540404/b4eadff4-c95b-403c-bac1-8eb8da39f7a5)


